### PR TITLE
Lighter button color when viewing in theater mode

### DIFF
--- a/main.js
+++ b/main.js
@@ -1,7 +1,7 @@
 // ==UserScript==
 // @name         YouTube: Hide Watched Videos
 // @namespace    https://www.haus.gg/
-// @version      4.3.0
+// @version      4.3.1
 // @description  Hides watched videos from your YouTube subscriptions page
 // @author       Ev Haus
 // @author       netjeff
@@ -82,7 +82,10 @@
 	width: 40px;
 }
 
-html[dark] .YT-HWV-BUTTON {
+/* Match the button color to "dark" background (as of Feb 2020) */
+html[dark]         .YT-HWV-BUTTON,  /* for the "Dark theme" overall */
+ytd-masthead[dark] .YT-HWV-BUTTON   /* When watching in "theater mode" the top bar containing the button is always dark regardless of "Dark theme" */
+{
 	color: #EFEFEF;
 }
 


### PR DESCRIPTION
When the viewer is in "theater mode" (aka widescreen that fills browser window width) the top bar containing the button is always dark, regardless of the overall Dark Theme.  I've updated the css to use lighter button color in theater mode, same as with Dark Theme.