### PR TITLE
Add '/c/' as an indicator that we're on a channel page

### DIFF
--- a/main.js
+++ b/main.js
@@ -174,7 +174,7 @@ ytd-masthead[dark] .YT-HWV-BUTTON   /* When watching in "theater mode" the top b
 		let youtubeSection = 'misc';
 		if (window.location.href.indexOf('/watch?') > 0) {
 			youtubeSection = 'watch';
-		} else if (window.location.href.match(/.*\/(user|channel)\/.+\/videos/u)) {
+		} else if (window.location.href.match(/.*\/(user|channel|c)\/.+\/videos/u)) {
 			youtubeSection = 'channel';
 		} else if (window.location.href.indexOf('/feed/subscriptions') > 0) {
 			youtubeSection = 'subscriptions';


### PR DESCRIPTION
Hey,

so for example look at this channel:

https://www.youtube.com/c/KitbogaShow/videos

you see that there's only a /c/ in this link. I've added that in the code so that channels are correctly recognized.

Greetings