### PR TITLE
Adopt new channel url

### DIFF
--- a/main.user.js
+++ b/main.user.js
@@ -221,7 +221,7 @@ ytd-masthead[dark] .YT-HWV-BUTTON-STYLE   /* In "Theater mode" the top bar conta
 		let youtubeSection = 'misc';
 		if (href.includes('/watch?')) {
 			youtubeSection = 'watch';
-		} else if (href.match(/.*\/(user|channel|c)\/.+\/videos/u)) {
+		} else if (href.match(/.*\/(user|channel|c)\/.+\/videos/u) || href.match(/.*\/@.*/u)) {
 			youtubeSection = 'channel';
 		} else if (href.includes('/feed/subscriptions')) {
 			youtubeSection = 'subscriptions';


### PR DESCRIPTION
Youtube now uses a new format of channel and channel sub-pages url. For example:

`https://www.youtube.com/@veritasium`
`https://www.youtube.com/@veritasium/videos`
`https://www.youtube.com/@veritasium/shorts`

Adding the regex to identify the new url format to better match the section where settings are applied. The old format is kept to ensure backward compatibility.