### PR TITLE
Add noframes to prevent activating on non-YT sites with embeded videos

### DIFF
--- a/main.user.js
+++ b/main.user.js
@@ -11,6 +11,7 @@
 // @match        http://youtube.com/*
 // @match        https://*.youtube.com/*
 // @match        https://youtube.com/*
+// @noframes
 // @require      https://openuserjs.org/src/libs/sizzle/GM_config.js
 // @grant        GM_getValue
 // @grant        GM_setValue


### PR DESCRIPTION
Per title, most users would prefer scripts like this only trigger when on the target domain.
I would not expect this script to be running when outside of youtube.com URLs just because an embedded video.

An alternative to this method, might be adding exclude URLs. But this stops the issue completely with a simple change.