### PR TITLE
Attempted fix for the shorts containers still showing up

### DIFF
--- a/main.user.js
+++ b/main.user.js
@@ -24,7 +24,7 @@
 
 (function (_undefined) {
 	// Enable for debugging
-	const DEBUG = true;
+	const DEBUG = false;
 
 	// Needed to bypass YouTube's Trusted Types restrictions, ie.
 	// Uncaught TypeError: Failed to set the 'innerHTML' property on 'Element': This document requires 'TrustedHTML' assignment.

--- a/main.user.js
+++ b/main.user.js
@@ -24,7 +24,7 @@
 
 (function (_undefined) {
 	// Enable for debugging
-	const DEBUG = false;
+	const DEBUG = true;
 
 	// Needed to bypass YouTube's Trusted Types restrictions, ie.
 	// Uncaught TypeError: Failed to set the 'innerHTML' property on 'Element': This document requires 'TrustedHTML' assignment.
@@ -208,6 +208,10 @@
 
 	const findShortsContainers = function () {
 		const shortsContainers = [
+			// All pages
+			document.querySelectorAll(
+				'[is-shorts]',
+			),
 			// Subscriptions Page (List View)
 			document.querySelectorAll(
 				'ytd-reel-shelf-renderer ytd-reel-item-renderer',


### PR DESCRIPTION
Added '[is-shorts]' to the findShortsContainers list, not sure if this is considered too hacky or not but it does work.