### PR TITLE
Alternative attempted fix for the shorts containers still showing up

### DIFF
--- a/main.user.js
+++ b/main.user.js
@@ -216,7 +216,7 @@
 				'ytd-rich-shelf-renderer ytd-rich-grid-slim-media',
 			),
 			// Home Page & Subscriptions Page (Grid View)
-			document.querySelectorAll('ytd-reel-shelf-renderer ytd-thumbnail'),
+			document.querySelectorAll("[id='content']"),
 			// Search results page
 			document.querySelectorAll(
 				'ytd-reel-shelf-renderer .ytd-reel-shelf-renderer',


### PR DESCRIPTION
Alternative fix for #248, in case #249 isn't validated.
This selects the div element with id 'content', which seems to be the container holding the shorts.