### PR TITLE
fix: use GM storage instead of localStorage for toggle state

### DIFF
--- a/main.user.js
+++ b/main.user.js
@@ -82,13 +82,31 @@ const REGEX_USER = /.*\/@.*/u;
 	// localStorage clears) but fall back to localStorage if GM APIs
 	// are unavailable.
 	const stateGet = async (key, defaultValue) => {
-		try { return GM_getValue(key, defaultValue); } catch (_) { /* fall through */ }
-		try { return await GM.getValue(key, defaultValue); } catch (_) { /* fall through */ }
+		try {
+			return GM_getValue(key, defaultValue);
+		} catch (_) {
+			/* fall through */
+		}
+		try {
+			return await GM.getValue(key, defaultValue);
+		} catch (_) {
+			/* fall through */
+		}
 		return localStorage.getItem(key) ?? defaultValue;
 	};
 	const stateSet = async (key, value) => {
-		try { GM_setValue(key, value); return; } catch (_) { /* fall through */ }
-		try { await GM.setValue(key, value); return; } catch (_) { /* fall through */ }
+		try {
+			GM_setValue(key, value);
+			return;
+		} catch (_) {
+			/* fall through */
+		}
+		try {
+			await GM.setValue(key, value);
+			return;
+		} catch (_) {
+			/* fall through */
+		}
 		localStorage.setItem(key, value);
 	};
 
@@ -452,7 +470,9 @@ const REGEX_USER = /.*\/@.*/u;
 			// For toggle buttons, determine where in GM storage they track state
 			const section = determineYoutubeSection();
 			const storageKey = stateKey ? [stateKey, section].join('_') : null;
-			const toggleButtonState = storageKey ? await stateGet(storageKey, 'normal') : 'normal';
+			const toggleButtonState = storageKey
+				? await stateGet(storageKey, 'normal')
+				: 'normal';
 
 			// Generate button DOM
 			const button = document.createElement('button');
@@ -487,9 +507,9 @@ const REGEX_USER = /.*\/@.*/u;
 					});
 					break;
 				case 'settings':
-					button.addEventListener('click', () => {
+					button.addEventListener('click', async () => {
 						gmc.open();
-						renderButtons();
+						await renderButtons();
 					});
 					break;
 			}


### PR DESCRIPTION
fixes #224 

YouTube clears localStorage on page load, which wipes the YTHWV_STATE_* keys that track toggle state (hidden/dimmed/normal). Switch to GM storage APIs so that toggle state persists across page reloads.

- Add async stateGet/stateSet helpers that try GM_getValue/GM_setValue, then GM.getValue/GM.setValue (Promise-based), then localStorage
- Grant GM.getValue and GM.setValue for userscript managers that only support the modern async API (e.g. Userscripts for Safari)
- Make updateClassOnWatchedItems, updateClassOnShortsItems, renderButtons, and run async to support awaiting GM storage
- Bump version to 6.15